### PR TITLE
fix: path to golangci-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
     - stage: lint
       script:
         - go get -v -t -d ./...
-        - golangci-lint run --config .golangci.yml
+        - ./bin/golangci-lint run --config .golangci.yml
     - stage: test
       script: go test -v -race -cover ./...
     - stage: build


### PR DESCRIPTION
Fix the following CI error:

```
$ golangci-lint run --config .golangci.yml
golangci-lint: command not found
```

Ref: https://travis-ci.com/tani-yu/dogleash/jobs/179058990#L545-L547