### PR TITLE
Add version command to print the version of DogLeash CLI tool

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package version
+package cmd
 
 import (
 	"fmt"
 	"runtime"
-
-	"github.com/tani-yu/dogleash/cmd"
 
 	"github.com/spf13/cobra"
 )
@@ -34,7 +32,7 @@ var versionCmd = &cobra.Command{
 }
 
 func init() {
-	cmd.RootCmd.AddCommand(versionCmd)
+	RootCmd.AddCommand(versionCmd)
 }
 
 func printVersion(cmd *cobra.Command, args []string) {

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import "github.com/tani-yu/dogleash/cmd"
 import _ "github.com/tani-yu/dogleash/cmd/dashboard"
 import _ "github.com/tani-yu/dogleash/cmd/monitor"
-import _ "github.com/tani-yu/dogleash/cmd/version"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR contains the feature to print the version of DogLeash CLI tool and its build information. These information would be added to the Environment section in the bug report when submitting a Issue.

**Which issue(s) this PR fixes**
Fixes: #25 

**Special notes for your reviewer** *(optional)*:
None
