### PR TITLE
fix "import" to specify Multiple files and Refactoring function

### DIFF
--- a/cmd/monitor/import.go
+++ b/cmd/monitor/import.go
@@ -70,7 +70,7 @@ func init() {
 func checkNameAndID(monit datadog.Monitor, cli *datadog.Client) bool {
 	mons, err := cli.GetMonitors()
 	for _, mon := range mons {
-		if *mon.Id == *monit.Id || *mon.Name == *monit.Name {
+		if *mon.Name == *monit.Name && *mon.Id == *monit.Id {
 			return false
 		}
 	}

--- a/cmd/monitor/import.go
+++ b/cmd/monitor/import.go
@@ -50,10 +50,9 @@ var monitorImportCmd = &cobra.Command{
 			}
 
 			if err := json.Unmarshal(raw, &decoded); err != nil {
-				log.Fatalf("JSON Unmarshal error:", err)
+				log.Fatalf("JSON Unmarshal error: %s\n", err)
 			}
 			monits = append(monits, decoded...)
-
 		}
 
 		mons, err := cli.GetMonitors()

--- a/cmd/monitor/import.go
+++ b/cmd/monitor/import.go
@@ -57,13 +57,17 @@ var monitorImportCmd = &cobra.Command{
 				fmt.Println("JSON Unmarshal error:", err)
 				return
 			}
-
 			monits = append(monits, decoded...)
+
 		}
-		pp.Println(monits)
+
+		mons, err := cli.GetMonitors()
+		if err != nil {
+			log.Fatalf("fatal: %s\n", err)
+		}
 
 		for _, monit := range monits {
-			if checkNameAndID(monit, cli) {
+			if checkNameAndID(monit, mons) {
 				fmt.Printf("CREATE  ID:%d, NAME:%s\n", *monit.Id, *monit.Name)
 				_, err := cli.CreateMonitor(&monit)
 				if err != nil {
@@ -81,16 +85,11 @@ func init() {
 }
 
 // Check if there is the same id and name
-func checkNameAndID(monit datadog.Monitor, cli *datadog.Client) bool {
-	mons, err := cli.GetMonitors()
+func checkNameAndID(monit datadog.Monitor, mons []datadog.Monitor) bool {
 	for _, mon := range mons {
 		if *mon.Name == *monit.Name || *mon.Id == *monit.Id {
 			return false
 		}
 	}
-	if err != nil {
-		log.Fatalf("fatal: %s\n", err)
-	}
-
 	return true
 }

--- a/cmd/monitor/import.go
+++ b/cmd/monitor/import.go
@@ -33,7 +33,7 @@ var monitorImportCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cli, err := dd.NewDDClient()
 		if err != nil {
-			log.Fatalf("Failed to connect Datadog API server: %s\n", err)
+			log.Fatalf("failed to connect Datadog API server: %s\n", err)
 		}
 
 		var monits []datadog.Monitor
@@ -41,7 +41,7 @@ var monitorImportCmd = &cobra.Command{
 			var decoded []datadog.Monitor
 			raw, err := ioutil.ReadFile(inputPath)
 			if err != nil {
-				log.Fatalf("fatal: %s\n", err)
+				log.Fatalf("failed to read JSON file: %s\n", err)
 			}
 
 			if err := json.Unmarshal(raw, &decoded); err != nil {
@@ -52,7 +52,7 @@ var monitorImportCmd = &cobra.Command{
 
 		mons, err := cli.GetMonitors()
 		if err != nil {
-			log.Fatalf("fatal: %s\n", err)
+			log.Fatalf("failed to get monitoring items: %s\n", err)
 		}
 
 		for _, monit := range monits {
@@ -60,7 +60,7 @@ var monitorImportCmd = &cobra.Command{
 				fmt.Printf("CREATE  ID:%d, NAME:%s\n", *monit.Id, *monit.Name)
 				_, err := cli.CreateMonitor(&monit)
 				if err != nil {
-					log.Fatalf("fatal: %s\n", err)
+					log.Fatalf("failed to create monitoring items: %s\n", err)
 				}
 			}
 		}

--- a/cmd/monitor/import.go
+++ b/cmd/monitor/import.go
@@ -51,7 +51,6 @@ var monitorImportCmd = &cobra.Command{
 
 			if err := json.Unmarshal(raw, &decoded); err != nil {
 				log.Fatalf("JSON Unmarshal error:", err)
-				return
 			}
 			monits = append(monits, decoded...)
 

--- a/cmd/monitor/import.go
+++ b/cmd/monitor/import.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
 
 	dd "github.com/tani-yu/dogleash/datadog"
 
@@ -43,7 +42,6 @@ var monitorImportCmd = &cobra.Command{
 			raw, err := ioutil.ReadFile(inputPath)
 			if err != nil {
 				log.Fatalf("fatal: %s\n", err)
-				os.Exit(1)
 			}
 
 			if err := json.Unmarshal(raw, &decoded); err != nil {

--- a/cmd/monitor/import.go
+++ b/cmd/monitor/import.go
@@ -40,10 +40,6 @@ var monitorImportCmd = &cobra.Command{
 			log.Fatalf("Failed to connect Datadog API server: %s\n", err)
 		}
 
-		if len(target) == 0 {
-			fmt.Println("Hello", target)
-		}
-
 		var monits []datadog.Monitor
 		for _, inputPath := range args {
 			var decoded []datadog.Monitor
@@ -54,7 +50,7 @@ var monitorImportCmd = &cobra.Command{
 			}
 
 			if err := json.Unmarshal(raw, &decoded); err != nil {
-				fmt.Println("JSON Unmarshal error:", err)
+				log.Fatalf("JSON Unmarshal error:", err)
 				return
 			}
 			monits = append(monits, decoded...)

--- a/cmd/monitor/import.go
+++ b/cmd/monitor/import.go
@@ -27,9 +27,6 @@ import (
 	datadog "gopkg.in/zorkian/go-datadog-api.v2"
 )
 
-//var inputPath string
-var target string
-
 // monitorImportCmd represents the monitorImportCmd command
 var monitorImportCmd = &cobra.Command{
 	Use:   "import",
@@ -74,8 +71,6 @@ var monitorImportCmd = &cobra.Command{
 
 func init() {
 	monitorCmd.AddCommand(monitorImportCmd)
-	// Create flags in order to specify the mulitpe files.
-	monitorImportCmd.Flags().StringVarP(&target, "target", "t", "world", "")
 }
 
 // Check if there is the same id and name


### PR DESCRIPTION
I fix "import" subcommand can receives all json files in the current directory #18 . 
And I refactor the code that "import" for spliting feature of checkNameAndID function #17
This code says checkNameAndID function only checks for the same name and the same ID.
If the same name and same ID do not create monitoring items.