### PR TITLE
os.Exit is duplicated

### DIFF
--- a/cmd/monitor/import.go
+++ b/cmd/monitor/import.go
@@ -42,7 +42,6 @@ var monitorImportCmd = &cobra.Command{
 		raw, err := ioutil.ReadFile(inputPath)
 		if err != nil {
 			log.Fatalf("fatal: %s\n", err)
-			os.Exit(1)
 		}
 
 		var monits []datadog.Monitor

--- a/cmd/monitor/import.go
+++ b/cmd/monitor/import.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
 
 	dd "github.com/tani-yu/dogleash/datadog"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

no need `os.Exit(1)` after `Fatal`.