### PR TITLE
feat: Automate binary release with GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,29 @@
+before:
+  hooks:
+  - go mod download
+builds:
+  - binary: dogleash
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+changelog:
+  filters:
+    exclude:
+      - .github
+      - Merge pull request
+      - Merge branch
+archive:
+  format: tar.gz
+  name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+  files:
+    - README.md
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    amd64: x86_64
+release:
+  github:
+    owner: tani-yu
+    name: dogleash

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,9 @@ jobs:
       script: go test -v -race -cover ./...
     - stage: build
       script: go build
+deploy:
+  - provider: script
+    skip_cleanup: true
+    script: curl -sL https://git.io/goreleaser | bash
+    on:
+      tags: true


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR automates binary release of dogleash for macOS and Linux users. When the developer pushes commit with a release tag such as `v0.1.0`, Travis CI starts GoReleaser's deploying job and uploads artifacts on release page.

**Which issue(s) this PR fixes**
None

**Special notes for your reviewer**:
Ref: https://goreleaser.com/ci/