### PR TITLE
Add subcommand config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ apikey = YOUR_API_KEY
 appkey = YOUR_APP_KEY
 ```
 
+Or, Create a dogleash config `~/.config/dogleash/config.yml`. Example:
+
+```yaml
+current: dogrc
+organizations:
+- apikey: hoge
+  appkey: hogehoge
+  name: hoge
+- apikey: fuga
+  appkey: fugafuga
+  name: fuga
+```
+
 You can skip this step if you already use [dogshell](https://docs.datadoghq.com/developers/faq/dogshell-quickly-use-datadog-s-api-from-terminal-shell/) and have `~/.dogrc` file.
 
 You can also use environment variables `DATADOG_API_KEY` and `DATADOG_APP_KEY`.

--- a/cmd/config/get.go
+++ b/cmd/config/get.go
@@ -1,16 +1,16 @@
 package config
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
-	"bufio"
 
 	"github.com/spf13/cobra"
 )
 
 var configGetCmd = &cobra.Command{
-	Use: "get",
+	Use:   "get",
 	Short: "Get Config Organization for API/APP keys",
 	Run: func(cmd *cobra.Command, args []string) {
 		dogrcFile = filepath.Join(os.Getenv("HOME"), ".dogrc.d/current")

--- a/cmd/config/get.go
+++ b/cmd/config/get.go
@@ -1,29 +1,22 @@
 package config
 
 import (
-	"bufio"
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var configGetCmd = &cobra.Command{
 	Use:   "get",
-	Short: "Get Config Organization for API/APP keys",
+	Short: "Get a Config name is set",
 	Run: func(cmd *cobra.Command, args []string) {
-		dogrcFile = filepath.Join(os.Getenv("HOME"), ".dogrc.d/current")
-		file, err := os.Open(dogrcFile)
+		viper.SetConfigFile(dogleashFile)
+		err := viper.ReadInConfig()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%v\n", err)
-			os.Exit(1)
+			panic(fmt.Errorf("Fatal error config file: %s", err))
 		}
-		defer file.Close()
-		scanner := bufio.NewScanner(file)
-		for scanner.Scan() {
-			fmt.Println(scanner.Text())
-		}
+		fmt.Println(viper.GetString("current"))
 	},
 }
 

--- a/cmd/config/get.go
+++ b/cmd/config/get.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -9,12 +10,12 @@ import (
 
 var configGetCmd = &cobra.Command{
 	Use:   "get",
-	Short: "Get a Config name is set",
+	Short: "current config name",
 	Run: func(cmd *cobra.Command, args []string) {
 		viper.SetConfigFile(dogleashFile)
 		err := viper.ReadInConfig()
 		if err != nil {
-			panic(fmt.Errorf("Fatal error config file: %s", err))
+			log.Fatal(err)
 		}
 		fmt.Println(viper.GetString("current"))
 	},

--- a/cmd/config/get.go
+++ b/cmd/config/get.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"bufio"
+
+	"github.com/spf13/cobra"
+)
+
+var configGetCmd = &cobra.Command{
+	Use: "get",
+	Short: "Get Config Organization for API/APP keys",
+	Run: func(cmd *cobra.Command, args []string) {
+		dogrcFile = filepath.Join(os.Getenv("HOME"), ".dogrc.d/current")
+		file, err := os.Open(dogrcFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(1)
+		}
+		defer file.Close()
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			fmt.Println(scanner.Text())
+		}
+	},
+}
+
+func init() {
+	configCmd.AddCommand(configGetCmd)
+}

--- a/cmd/config/list.go
+++ b/cmd/config/list.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"io/ioutil"
+
+	"github.com/spf13/cobra"
+)
+
+var configListCmd = &cobra.Command{
+        Use: "list",
+        Short: "list Organization configs",
+        Run: func(cmd *cobra.Command, args []string) {
+		files, err := ioutil.ReadDir(filepath.Join(os.Getenv("HOME"), ".dogrc.d"))
+		if err != nil {
+		        fmt.Fprintf(os.Stderr, "%v\n", err)
+		        os.Exit(1)
+		}
+		for _, f := range files {
+			if f.Name() == "current" {
+				continue
+			}
+			fmt.Println(f.Name())
+		}
+	},
+}
+
+func init() {
+	configCmd.AddCommand(configListCmd)
+}

--- a/cmd/config/list.go
+++ b/cmd/config/list.go
@@ -11,13 +11,13 @@ import (
 
 var configListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "list configs",
+	Short: "show list of all config names",
 	Run: func(cmd *cobra.Command, args []string) {
 		// read config
 		viper.SetConfigFile(dogleashFile)
 		err := viper.ReadInConfig()
 		if err != nil {
-			panic(fmt.Errorf("Fatal error config file: %s", err))
+			log.Fatal(err)
 		}
 
 		err = viper.Unmarshal(&DC)
@@ -27,11 +27,9 @@ var configListCmd = &cobra.Command{
 
 		// print configs
 		for _, o := range DC.Organizations {
-			fmt.Printf("%s\t", o.Name)
+			fmt.Println(o.Name)
 		}
-		if _, err = os.Stat(dogrcFile); err != nil {
-			fmt.Println()
-		} else {
+		if _, err = os.Stat(dogrcFile); err == nil {
 			fmt.Println("dogrc")
 		}
 	},

--- a/cmd/config/list.go
+++ b/cmd/config/list.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -18,10 +19,15 @@ var configListCmd = &cobra.Command{
 		if err != nil {
 			panic(fmt.Errorf("Fatal error config file: %s", err))
 		}
+
+		err = viper.Unmarshal(&DC)
+		if err != nil {
+			log.Fatal(err)
+		}
+
 		// print configs
-		od := viper.Get("organizations")
-		for i := 0; i < len(od.([]interface{})); i++ {
-			fmt.Printf("%s\t", od.([]interface{})[i].(map[interface{}]interface{})["name"])
+		for _, o := range DC.Organizations {
+			fmt.Printf("%s\t", o.Name)
 		}
 		if _, err = os.Stat(dogrcFile); err != nil {
 			fmt.Println()

--- a/cmd/config/list.go
+++ b/cmd/config/list.go
@@ -2,27 +2,31 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var configListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "list Organization configs",
+	Short: "list configs",
 	Run: func(cmd *cobra.Command, args []string) {
-		files, err := ioutil.ReadDir(filepath.Join(os.Getenv("HOME"), ".dogrc.d"))
+		// read config
+		viper.SetConfigFile(dogleashFile)
+		err := viper.ReadInConfig()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%v\n", err)
-			os.Exit(1)
+			panic(fmt.Errorf("Fatal error config file: %s", err))
 		}
-		for _, f := range files {
-			if f.Name() == "current" {
-				continue
-			}
-			fmt.Println(f.Name())
+		// print configs
+		od := viper.Get("organizations")
+		for i := 0; i < len(od.([]interface{})); i++ {
+			fmt.Printf("%s\t", od.([]interface{})[i].(map[interface{}]interface{})["name"])
+		}
+		if _, err = os.Stat(dogrcFile); err != nil {
+			fmt.Println()
+		} else {
+			fmt.Println("dogrc")
 		}
 	},
 }

--- a/cmd/config/list.go
+++ b/cmd/config/list.go
@@ -2,21 +2,21 @@ package config
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
-	"io/ioutil"
 
 	"github.com/spf13/cobra"
 )
 
 var configListCmd = &cobra.Command{
-        Use: "list",
-        Short: "list Organization configs",
-        Run: func(cmd *cobra.Command, args []string) {
+	Use:   "list",
+	Short: "list Organization configs",
+	Run: func(cmd *cobra.Command, args []string) {
 		files, err := ioutil.ReadDir(filepath.Join(os.Getenv("HOME"), ".dogrc.d"))
 		if err != nil {
-		        fmt.Fprintf(os.Stderr, "%v\n", err)
-		        os.Exit(1)
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(1)
 		}
 		for _, f := range files {
 			if f.Name() == "current" {

--- a/cmd/config/root.go
+++ b/cmd/config/root.go
@@ -1,11 +1,15 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/spf13/cobra"
 	"github.com/tani-yu/dogleash/cmd"
 )
 
-var dogrcFile string
+var dogrcFile = filepath.Join(os.Getenv("HOME"), ".dogrc")
+var dogleashFile = filepath.Join(os.Getenv("HOME"), ".config/dogleash/config.yml")
 
 var configCmd = &cobra.Command{
 	Use:   "config",

--- a/cmd/config/root.go
+++ b/cmd/config/root.go
@@ -21,7 +21,7 @@ type Organization struct {
 	APPKey string `mapstructure:"appkey"`
 }
 
-// dogleash map-struct
+// DC dogleash config
 var DC DogleashConfig
 
 // config path

--- a/cmd/config/root.go
+++ b/cmd/config/root.go
@@ -8,21 +8,8 @@ import (
 	"github.com/tani-yu/dogleash/cmd"
 )
 
-// dogleash config current and orgs
-type DogleashConfig struct {
-	Organizations []Organization
-	Current       string `mapstructure:"current"`
-}
-
-// orgs
-type Organization struct {
-	Name   string `mapstructure:"name"`
-	APIKey string `mapstructure:"apikey"`
-	APPKey string `mapstructure:"appkey"`
-}
-
 // DC dogleash config
-var DC DogleashConfig
+var DC cmd.DogleashConfig
 
 // config path
 var dogrcFile = filepath.Join(os.Getenv("HOME"), ".dogrc")

--- a/cmd/config/root.go
+++ b/cmd/config/root.go
@@ -17,7 +17,7 @@ var dogleashFile = filepath.Join(os.Getenv("HOME"), ".config/dogleash/config.yml
 
 var configCmd = &cobra.Command{
 	Use:   "config",
-	Short: "Perform operations related to config of Datadog API/APP keys",
+	Short: "Manage config files of Datadog API/APP keys",
 }
 
 func init() {

--- a/cmd/config/root.go
+++ b/cmd/config/root.go
@@ -1,14 +1,14 @@
 package config
 
 import (
-	"github.com/tani-yu/dogleash/cmd"
 	"github.com/spf13/cobra"
+	"github.com/tani-yu/dogleash/cmd"
 )
 
 var dogrcFile string
 
 var configCmd = &cobra.Command{
-	Use: "config",
+	Use:   "config",
 	Short: "Perform operations related to config of Datadog API/APP keys",
 }
 

--- a/cmd/config/root.go
+++ b/cmd/config/root.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"github.com/tani-yu/dogleash/cmd"
+	"github.com/spf13/cobra"
+)
+
+var dogrcFile string
+
+var configCmd = &cobra.Command{
+	Use: "config",
+	Short: "Perform operations related to config of Datadog API/APP keys",
+}
+
+func init() {
+	cmd.RootCmd.AddCommand(configCmd)
+}

--- a/cmd/config/root.go
+++ b/cmd/config/root.go
@@ -8,6 +8,23 @@ import (
 	"github.com/tani-yu/dogleash/cmd"
 )
 
+// dogleash config current and orgs
+type DogleashConfig struct {
+	Organizations []Organization
+	Current       string `mapstructure:"current"`
+}
+
+// orgs
+type Organization struct {
+	Name   string `mapstructure:"name"`
+	APIKey string `mapstructure:"apikey"`
+	APPKey string `mapstructure:"appkey"`
+}
+
+// dogleash map-struct
+var DC DogleashConfig
+
+// config path
 var dogrcFile = filepath.Join(os.Getenv("HOME"), ".dogrc")
 var dogleashFile = filepath.Join(os.Getenv("HOME"), ".config/dogleash/config.yml")
 

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+var configSetCmd = &cobra.Command{
+	Use: "set",
+	Short: "Set Config Organization for API/APP keys",
+	Run: func(cmd *cobra.Command, args []string) {
+		var file *os.File
+		if len(args) == 1 {
+			dogrcFile = filepath.Join(os.Getenv("HOME"), ".dogrc.d/current")
+			_, err := os.Stat(dogrcFile)
+			if err != nil {
+				file, err = os.OpenFile(dogrcFile, os.O_WRONLY|os.O_CREATE, 0644)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%v\n", err)
+					os.Exit(1)
+				}
+				defer file.Close()
+			} else {
+				file, err = os.OpenFile(dogrcFile, os.O_WRONLY|os.O_TRUNC, 0644)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%v\n", err)
+					os.Exit(1)
+				}
+				defer file.Close()
+			}
+			fmt.Fprintf(file, args[0])
+		} else {
+			fmt.Fprintf(os.Stderr, "set <config>\n")
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	configCmd.AddCommand(configSetCmd)
+}

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -1,42 +1,109 @@
 package config
 
 import (
+	"bufio"
 	"fmt"
+	"io"
+	"log"
 	"os"
-	"path/filepath"
+	"strconv"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var configSetCmd = &cobra.Command{
 	Use:   "set",
-	Short: "Set Config Organization for API/APP keys",
+	Short: "Set a Config for API/APP keys",
 	Run: func(cmd *cobra.Command, args []string) {
-		var file *os.File
-		if len(args) == 1 {
-			dogrcFile = filepath.Join(os.Getenv("HOME"), ".dogrc.d/current")
-			_, err := os.Stat(dogrcFile)
-			if err != nil {
-				file, err = os.OpenFile(dogrcFile, os.O_WRONLY|os.O_CREATE, 0644)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "%v\n", err)
-					os.Exit(1)
-				}
-				defer file.Close()
-			} else {
-				file, err = os.OpenFile(dogrcFile, os.O_WRONLY|os.O_TRUNC, 0644)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "%v\n", err)
-					os.Exit(1)
-				}
-				defer file.Close()
-			}
-			fmt.Fprintf(file, args[0])
+		// read config
+		viper.SetConfigFile(dogleashFile)
+		err := viper.ReadInConfig()
+		if err != nil {
+			panic(fmt.Errorf("Fatal error config file: %s", err))
+		}
+
+		var dogrcExist bool
+		_, err = os.Stat(dogrcFile)
+		if err != nil {
+			dogrcExist = false
 		} else {
-			fmt.Fprintf(os.Stderr, "set <config>\n")
-			os.Exit(1)
+			dogrcExist = true
+		}
+
+		od := viper.Get("organizations")
+		if len(args) == 1 {
+			// check configs
+			/*
+				* config exist: update
+				* dogrc exist: update
+					* dogrc not exist: error
+				* others: choose a config
+			*/
+			for i := 0; i < len(od.([]interface{})); i++ {
+				if args[0] == od.([]interface{})[i].(map[interface{}]interface{})["name"] {
+					// config exist: update
+					UpdateCurrent(args[0])
+					return
+				} else if args[0] == "dogrc" {
+					if dogrcExist {
+						// dogrc exist: update
+						UpdateCurrent(args[0])
+						return
+					} else {
+						// dogrc not exist: error
+						log.Fatalf("\ndoes not exist %s\n", dogrcFile)
+					}
+				}
+
+			}
+			// others: choose a config
+			ChooseConfig()
+		} else {
+			// choose a config
+			ChooseConfig()
 		}
 	},
+}
+
+func UpdateCurrent(arg string) {
+	viper.Set("current", arg)
+	err := viper.WriteConfigAs(dogleashFile)
+	if err != nil {
+		panic(fmt.Errorf("Fatal error config file: %s", err))
+	}
+}
+
+func ChooseConfig() {
+	// list configs
+	od := viper.Get("organizations")
+	lenod := len(od.([]interface{}))
+
+	fmt.Println("Choose a Config name")
+	for i := 0; i < lenod; i++ {
+		fmt.Printf("[%d] %s\n", i, od.([]interface{})[i].(map[interface{}]interface{})["name"])
+	}
+	if _, err := os.Stat(dogrcFile); err == nil {
+		fmt.Printf("[%d] dogrc\n", lenod)
+	}
+
+	// wait user input
+	io.WriteString(os.Stdout, "input number: ")
+	sc := bufio.NewScanner(os.Stdin)
+	sc.Scan()
+	n, err := strconv.Atoi(sc.Text())
+	if err != nil {
+		log.Fatalf("\nChoose valid number.\n%s\n", err)
+	}
+
+	// update current
+	if n < lenod {
+		UpdateCurrent(od.([]interface{})[n].(map[interface{}]interface{})["name"].(string))
+	} else if n == lenod {
+		UpdateCurrent("dogrc")
+	} else {
+		log.Fatal("\nChoose valid number.\n")
+	}
 }
 
 func init() {

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -9,7 +9,7 @@ import (
 )
 
 var configSetCmd = &cobra.Command{
-	Use: "set",
+	Use:   "set",
 	Short: "Set Config Organization for API/APP keys",
 	Run: func(cmd *cobra.Command, args []string) {
 		var file *os.File

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -14,13 +14,13 @@ import (
 
 var configSetCmd = &cobra.Command{
 	Use:   "set",
-	Short: "Set a Config for API/APP keys",
+	Short: "Set API/APP keys per organization",
 	Run: func(cmd *cobra.Command, args []string) {
 		// read config
 		viper.SetConfigFile(dogleashFile)
 		err := viper.ReadInConfig()
 		if err != nil {
-			panic(fmt.Errorf("Fatal error config file: %s", err))
+			log.Fatal(err)
 		}
 
 		var dogrcExist bool
@@ -73,7 +73,7 @@ func UpdateCurrent(arg string) {
 	viper.Set("current", arg)
 	err := viper.WriteConfigAs(dogleashFile)
 	if err != nil {
-		panic(fmt.Errorf("Fatal error config file: %s", err))
+		log.Fatal(err)
 	}
 }
 

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -49,13 +49,12 @@ var configSetCmd = &cobra.Command{
 					if dogrcExist {
 						// dogrc exist: update
 						UpdateCurrent(args[0])
-						return
 					} else {
 						// dogrc not exist: error
 						log.Fatalf("\ndoes not exist %s\n", dogrcFile)
 					}
+					return
 				}
-
 			}
 			// others: choose a config
 			ChooseConfig()
@@ -66,6 +65,7 @@ var configSetCmd = &cobra.Command{
 	},
 }
 
+// UpdateCurrent set current config
 func UpdateCurrent(arg string) {
 	viper.Set("current", arg)
 	err := viper.WriteConfigAs(dogleashFile)
@@ -74,6 +74,7 @@ func UpdateCurrent(arg string) {
 	}
 }
 
+// ChooseConfig make user to choose config from list
 func ChooseConfig() {
 	// list configs
 	od := viper.Get("organizations")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,23 @@ import (
 	"gopkg.in/ini.v1"
 )
 
+// dogleash config current and orgs
+type DogleashConfig struct {
+	Organizations []Organization
+	Current       string `mapstructure:"current"`
+}
+
+// orgs
+type Organization struct {
+	Name   string `mapstructure:"name"`
+	APIKey string `mapstructure:"apikey"`
+	APPKey string `mapstructure:"appkey"`
+}
+
+// dogleash map-struct
+var DC DogleashConfig
+
+// config path
 var dogrcFile = filepath.Join(os.Getenv("HOME"), ".dogrc")
 var dogleashFile = filepath.Join(os.Getenv("HOME"), ".config/dogleash/config.yml")
 
@@ -77,9 +94,12 @@ func initConfigDDKey() {
 			panic(fmt.Errorf("Fatal error config file: %s", err))
 		}
 
-		cs := viper.Get("current")
-		od := viper.Get("organizations")
-		if cs == "dogrc" {
+		err = viper.Unmarshal(&DC)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if DC.Current == "dogrc" {
 			if dogrcExist {
 				dogrc, err := ini.Load(dogrcFile)
 				if err != nil {
@@ -91,10 +111,10 @@ func initConfigDDKey() {
 				log.Fatal("\ncurrent config is dogrc. but does not exist ~/.dogrc")
 			}
 		} else {
-			for i := 0; i < len(od.([]interface{})); i++ {
-				if od.([]interface{})[i].(map[interface{}]interface{})["name"] == cs {
-					viper.SetDefault("api_key", od.([]interface{})[i].(map[interface{}]interface{})["keys"].(map[interface{}]interface{})["apikey"])
-					viper.SetDefault("app_key", od.([]interface{})[i].(map[interface{}]interface{})["keys"].(map[interface{}]interface{})["appkey"])
+			for _, o := range DC.Organizations {
+				if o.Name == DC.Current {
+					viper.SetDefault("api_key", o.APIKey)
+					viper.SetDefault("app_key", o.APPKey)
 				}
 			}
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,7 +91,7 @@ func initConfigDDKey() {
 		viper.SetConfigFile(dogleashFile)
 		err := viper.ReadInConfig()
 		if err != nil {
-			panic(fmt.Errorf("Fatal error config file: %s", err))
+			log.Fatal(err)
 		}
 
 		err = viper.Unmarshal(&DC)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,7 +24,7 @@ type Organization struct {
 	APPKey string `mapstructure:"appkey"`
 }
 
-// dogleash map-struct
+// DC dogleash config
 var DC DogleashConfig
 
 // config path

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,13 +1,13 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
-	"bufio"
 
-	"github.com/spf13/viper"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"gopkg.in/ini.v1"
 )
 
@@ -41,12 +41,12 @@ func initConfig() {
 		return
 	} else if len(os.Args) != 2 {
 		switch os.Args[1] {
-			case "config":
-				return
-			case "help":
-				return
-			default:
-				initConfigDDKey()
+		case "config":
+			return
+		case "help":
+			return
+		default:
+			initConfigDDKey()
 		}
 	}
 }

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -15,6 +16,7 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
@@ -28,6 +30,7 @@ github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.3.1 h1:5+8j8FTpnFV4nEImW/ofkzEt8VoOiLXxdYIDsB73T38=
 github.com/spf13/viper v1.3.1/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import "github.com/tani-yu/dogleash/cmd"
 import _ "github.com/tani-yu/dogleash/cmd/dashboard"
 import _ "github.com/tani-yu/dogleash/cmd/monitor"
+import _ "github.com/tani-yu/dogleash/cmd/config"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
**What this PR does / why we need it**:

ika no bunsyou ha funiki to google-honyaku ni yotte sakusei simasita.

### request to
It is troublesome to specify config every time when switching some datadog organizations, so add sub-command `config`.
- dogleash config list/get/set
- location of config: `~/.dogrc.d/`
  - `~/dogrc.d/hoge`
  - `~/dogrc.d/fuga`
  - ...

#### working now
  - vipering
  - refactor
  - handling errors

#### how to use
```bash
$ doglesh config list
fuga
hoge
```

```bash
$ dogleash config get
hoge
```

```bash
$ dogleash config set fuga
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
nothing

Fixes #[PUT ISSUE NUMBER HERE]
nothing

**Special notes for your reviewer** *(optional)*:
yoroshiku onegai simasu
